### PR TITLE
New tracking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "astro-solid-ai-synth",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "astro-solid-ai-synth",
-      "version": "1.0.9",
+      "version": "1.0.10",
       "hasInstallScript": true,
       "dependencies": {
         "@otonashixav/solid-flip": "^0.10.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astro-solid-ai-synth",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "private": true,
   "author": {
     "name": "Roy Eden",

--- a/src/utils/model.ts
+++ b/src/utils/model.ts
@@ -1,7 +1,7 @@
 // TODO rename file to tracking as it concerns the tracking aspects
 import type { Results } from "@mediapipe/pose";
 import { DOM_NODE_REFERENCES } from "~store/global";
-import { MidiMapper, setupMidiMessages } from "./midi";
+import { MidiMapper, midiState } from "./midi";
 
 export const POSE_LANDMARKS_ORDER = [
   "NOSE",
@@ -40,6 +40,14 @@ export const POSE_LANDMARKS_ORDER = [
 ] as const;
 
 export type PoseLandmark = typeof POSE_LANDMARKS_ORDER[number];
+
+export const POSE_LANDMARKS_REVERSE_MAPPER = POSE_LANDMARKS_ORDER.reduce(
+  (mapper, landmark, index) => {
+    mapper[landmark as PoseLandmark] = index;
+    return mapper;
+  },
+  {} as { [Landmark in PoseLandmark]: number }
+);
 
 export const POSE_LANDMARKS_LABELS: {
   [Landmark in PoseLandmark]: string;
@@ -159,5 +167,5 @@ function drawKeypoints(results: Results) {
 
 export function onResults(results: Results) {
   drawKeypoints(results);
-  setupMidiMessages(results);
+  midiState.poseLandmarks = results.poseLandmarks;
 }


### PR DESCRIPTION
# Rethink note tracking (it was bugged):

## Reasoning:

* Issue: Notes were being built on a frame by frame basis even if they weren't used.
* Fix: Switched to an on-demand build of notes only when triggered by a noteOn message.

* Issue: Notes were buggy/not turning off correctly.
* Fix: This logic was remade. We now think of notes in relation to the channel that holds them & the triggers that hold them on that channel. This helps establish a simple one to many to many relationship\*:
  * `Trigger -> Channels -> Notes`
  * `Channel -> Notes -> Triggers`  

\*Perhaps it needs to be improved in performance to see how it scales, but it has been tested in a lower end device and it seems to work. Some other performance improvements may lead to reusing objects that are already created in memory, but it should also address possible memory issues by doing that, as this could scale to some big sets that maybe don't make sense to keep in memory.
